### PR TITLE
fix bug that "eval" hangs in named location

### DIFF
--- a/ngx_http_eval_module.c
+++ b/ngx_http_eval_module.c
@@ -353,6 +353,8 @@ ngx_http_eval_post_subrequest_handler(ngx_http_request_t *r, void *data, ngx_int
     /* dd("rc == %d", rc); */
     ctx->status = rc;
 
+    r->parent->write_event_handler = ngx_http_core_run_phases;
+
     return NGX_OK;
 }
 


### PR DESCRIPTION
I've tested with nginx-1.2.0 there still be such a bug in it.

I just made a fix to make it work but I am not sure if it is a best way to do this.
