### PR TITLE
maage: fix: use memchr to scan ngx_string

### DIFF
--- a/src/ngx_http_eval_module.c
+++ b/src/ngx_http_eval_module.c
@@ -514,7 +514,8 @@ ngx_http_eval_parse_param(ngx_http_request_t *r, ngx_http_eval_ctx_t *ctx,
     ngx_str_t                  name;
     ngx_str_t                  value;
 
-    p = (u_char *) ngx_strchr(param->data, '=');
+    /* param->data is not \0 terminated */
+    p = (u_char *) memchr(param->data, '=', param->len);
 
     if (p == NULL) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,


### PR DESCRIPTION
Field is not \0 terminated.

==13043==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x621000074100 at pc 0x563ba79d56c9 bp 0x7ffec6e4cf70 sp 0x7ffec6e4c720
READ of size 4097 at 0x621000074100 thread T0